### PR TITLE
Get rid of deprecation warnings

### DIFF
--- a/app/components/App.jsx
+++ b/app/components/App.jsx
@@ -8,12 +8,12 @@ var React = require('react');
 /**
  * App component.
  */
-module.exports = React.createClass({
-    render: function() {
+module.exports = class App extends React.Component {
+    render() {
         return (
             <h1>
                 Welcome to electron-react-template!
             </h1>
         );
     }
-});
+}

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "template"
   ],
   "dependencies": {
-    "react": "^15.0.2",
-    "react-dom": "^15.0.2"
+    "react": "^15.6.2",
+    "react-dom": "^15.6.2"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
     "react-dom": "^15.0.2"
   },
   "devDependencies": {
-    "babel-core": "^6.7.7",
-    "babel-loader": "^6.2.4",
-    "babel-preset-es2015": "^6.6.0",
-    "babel-preset-react": "^6.5.0",
+    "babel-core": "^6.26.0",
+    "babel-loader": "^6.4.1",
+    "babel-preset-env": "^1.6.0",
+    "babel-preset-react": "^6.24.1",
     "babel-preset-react-hmre": "^1.1.1",
     "electron-debug": "^0.7.0",
     "electron-prebuilt": "^0.37.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,7 +23,7 @@ module.exports = {
                 exclude: /node_modules/,
                 loader: 'babel', // 'babel-loader' is also a legal name to reference
                 query: {
-                    presets: ['react', 'es2015']
+                    presets: ['react', 'env']
                 }
             }
         ]

--- a/webpack.development.config.js
+++ b/webpack.development.config.js
@@ -42,7 +42,7 @@ module.exports = {
                 exclude: /node_modules/,
                 loader: 'babel',
                 query: {
-                    presets: ['es2015', 'react', 'react-hmre']
+                    presets: ['env', 'react', 'react-hmre']
                 }
             }
         ]


### PR DESCRIPTION
Hi there!

Like the simplicity of your template, thanks for that!

However, there are two deprecation warnings:

- babel `es2015` is deprecated in favor of `env`
- `React.createClass` is deprecated in favor of Javascript classes

This PR fixes those two warnings.